### PR TITLE
Use modern runtime functions to remove warnings

### DIFF
--- a/Commands/prototype/TMDChameleon.mm
+++ b/Commands/prototype/TMDChameleon.mm
@@ -1,19 +1,14 @@
 //
 //  TMDChameleon.mm
+//
 //  Created by Allan Odgaard on 2007-06-26.
+//  Copyright (c) 2007 MacroMates. All rights reserved.
 //
 
 #import "TMDChameleon.h"
-#import <objc/objc-runtime.h>
+#import <objc/runtime.h>
 
 static NSMutableDictionary* DefaultValues = [NSMutableDictionary new];
-
-static Class find_root (Class cl)
-{
-	while(cl->super_class)
-		cl = cl->super_class;
-	return cl;
-}
 
 @implementation TMD2Chameleon
 - (id)init
@@ -25,27 +20,18 @@ static Class find_root (Class cl)
 + (BOOL)createSubclassNamed:(NSString*)aName withValues:(NSDictionary*)values
 {
 	[DefaultValues setObject:values forKey:aName];
-	if(NSClassFromString(aName))
+	
+	const char* name = [aName UTF8String];
+	
+	if(objc_lookUpClass(name))
 		return YES;
-
-	Class super_cl       = [TMD2Chameleon class];
-
-	Class sub_cl         = (Class)calloc(1, sizeof(objc_class));
-	Class meta_cl        = (Class)calloc(1, sizeof(objc_class));
-
-	sub_cl->name         = strdup([aName UTF8String]);
-	sub_cl->info         = CLS_CLASS;
-	sub_cl->isa          = meta_cl;
-	sub_cl->super_class  = super_cl;
-	sub_cl->methodLists  = (objc_method_list**)calloc(1, sizeof(objc_method_list*));
-
-	meta_cl->name        = sub_cl->name;
-	meta_cl->info        = CLS_META;
-	meta_cl->isa         = find_root(super_cl)->isa;
-	meta_cl->super_class = super_cl->isa;
-	meta_cl->methodLists = (objc_method_list**)calloc(1, sizeof(objc_method_list*));
-
-	objc_addClass(sub_cl); 
+	
+	Class sub_cl = objc_allocateClassPair([TMD2Chameleon class], name, 0);
+	
+	if(sub_cl == Nil)
+		return NO;
+	
+	objc_registerClassPair(sub_cl);
 
 	return YES;
 }


### PR DESCRIPTION
Fixes warnings resulting from use of `struct objc_class` and members.
