### PR TITLE
DIALOG help improvements and x-insert returns 1 on stderr if it failed

### DIFF
--- a/Commands/Utilities/TextMate.h
+++ b/Commands/Utilities/TextMate.h
@@ -4,5 +4,5 @@
 - (NSPoint)positionForWindowUnderCaret;
 @end
 
-void insert_text (NSString* someText);
-void insert_snippet (NSString* aSnippet);
+BOOL insert_text (NSString* someText);
+BOOL insert_snippet (NSString* aSnippet);

--- a/Commands/Utilities/TextMate.mm
+++ b/Commands/Utilities/TextMate.mm
@@ -73,8 +73,9 @@ id frontMostTextViewForSelector(SEL selector, BOOL *isNew, NSWindow* *winForText
 
 /**
  Tries to insert “someText” as text into the front most text view.
+ Returns success status.
 */
-void insert_text (NSString* someText)
+BOOL insert_text (NSString* someText)
 {
 	BOOL isNewDocument = false;
 	if(id textView = frontMostTextViewForSelector(@selector(insertText:), &isNewDocument, NULL))
@@ -83,14 +84,16 @@ void insert_text (NSString* someText)
 			[textView performSelector:@selector(insertText:) withObject:someText afterDelay:insertionDelayForNewDoc];
 		else
 			[textView insertText:someText];
+		return true;
 	}
+	return false;
 }
 
 /**
  Tries to insert “aSnippet” as snippet into the front most text view
- and set the key focus to the current document.
+ and set the key focus to the current document. Returns success status.
 */
-void insert_snippet (NSString* aSnippet)
+BOOL insert_snippet (NSString* aSnippet)
 {
 	BOOL isNewDocument = false;
 	NSWindow *win = nil;
@@ -106,5 +109,7 @@ void insert_snippet (NSString* aSnippet)
 		// Since after inserting a snippet the user should interact with the snippet
 		// set key focus to current textView
 		[win makeKeyWindow];
+		return true;
 	}
+	return false;
 }

--- a/Commands/alert.mm
+++ b/Commands/alert.mm
@@ -57,7 +57,7 @@ NSAlertStyle alert_style_from_string (NSString* str)
 
 - (NSString *)commandDescription
 {
-	return @"Show an alert box.";
+	return @"Shows a customizable alert box.";
 }
 
 - (NSString *)usageForInvocation:(NSString *)invocation;

--- a/Commands/defaults.mm
+++ b/Commands/defaults.mm
@@ -33,7 +33,7 @@
 
 - (NSString *)commandDescription
 {
-	return @"Register default values for user settings.";
+	return @"Registers default values for user settings.";
 }
 
 - (NSString *)usageForInvocation:(NSString *)invocation;

--- a/Commands/images.mm
+++ b/Commands/images.mm
@@ -34,7 +34,7 @@
 
 - (NSString *)commandDescription
 {
-	return @"Add image files as named images for use by other commands/nibs.";
+	return @"Adds image files as named images for use by other commands/NIBs/XIBs.";
 }
 
 - (NSString *)usageForInvocation:(NSString *)invocation;

--- a/Commands/insert.mm
+++ b/Commands/insert.mm
@@ -14,10 +14,23 @@
 - (void)handleCommand:(CLIProxy*)proxy;
 {
 	NSDictionary* args = [proxy parameters];
-
+	BOOL success = NO;
 	if(NSString* text = [args objectForKey:@"text"])
-		insert_text(text);
+		success = insert_text(text);
 	else if(NSString* snippet = [args objectForKey:@"snippet"])
-		insert_snippet(snippet);
+		success = insert_snippet(snippet);
+	if(!success)
+		[[proxy errorHandle] writeString:@"1"];
 }
+
+- (NSString *)commandDescription
+{
+	return @"Tries to insert a text or a snippet into the front-most document.\nSTDERR returns on error “1” otherwise nothing.";
+}
+
+- (NSString *)usageForInvocation:(NSString *)invocation;
+{
+	return [NSString stringWithFormat:@"\t%1$@ --text 'This inserts a text.'\n\t%1$@ --snippet 'This ${1:inserts} a ${2:snippet}.'", invocation];
+}
+
 @end

--- a/Commands/nib/nib.mm
+++ b/Commands/nib/nib.mm
@@ -147,7 +147,7 @@ env|egrep 'DIALOG|TM_SUPPORT'|grep -v DIALOG_1|perl -pe 's/(.*?)=(.*)/export $1=
 
 - (NSString *)commandDescription
 {
-	return @"Displays custom dialogs from NIBs.";
+	return @"Displays custom dialogs from NIBs or XIBs.";
 }
 
 - (NSString *)usageForInvocation:(NSString *)invocation;

--- a/Commands/popup/popup.mm
+++ b/Commands/popup/popup.mm
@@ -53,7 +53,7 @@
 
 - (NSString *)commandDescription
 {
-	return @"Presents the user with a list of items which can be filtered down by typing to select the item they want.";
+	return @"Presents the user with a list of items which can be filtered down by typing.";
 }
 
 - (NSString *)usageForInvocation:(NSString *)invocation;

--- a/Commands/prototype/prototype.mm
+++ b/Commands/prototype/prototype.mm
@@ -37,7 +37,7 @@
 
 - (NSString *)commandDescription
 {
-	return @"Register classes for use with NSArrayController.";
+	return @"Registers classes for usage with NSArrayController.";
 }
 
 - (NSString *)usageForInvocation:(NSString *)invocation;


### PR DESCRIPTION
• $DIALOG help
- outputs informations sorted and structured
- distinguish between 'normal' commands and 'x-' commands which are marked as "API"
- made command descriptions a bit more consistent
  • 'x-' commands (API) should return an error status if the command failed
- now 'x-insert' returns 1 on stderr if it failed otherwise nothing on stderr
