### PR TITLE
fixup! Rework option parser to support ‘--’ as escape sequence

### DIFF
--- a/CLIProxy.mm
+++ b/CLIProxy.mm
@@ -52,8 +52,6 @@
 			NSString* arg = _arguments[i];
 			if([arg hasPrefix:@"--"] && ![arg isEqualToString:@"--"])
 			{
-				if(lastKey)
-					res[lastKey] = @""; // We use NSString because we may send mutableCopy to parameters
 				lastKey = [arg substringFromIndex:2];
 			}
 			else if(lastKey)
@@ -65,6 +63,8 @@
 				lastKey = nil;
 			}
 		}
+		if(lastKey)
+			res[lastKey] = @""; // We use NSString because we may send mutableCopy to parameters
 
 		_parameters = res;
 	}


### PR DESCRIPTION
I saw the discussion on the latex issue and I thought I should look into the problem with the dialog commands. This fixes the issue for `"$DIALOG" nib --list`, but  `"$DIALOG" nib --wait  «token»` works for me before this change (unless you were referring to when no argument was passed to `--wait` and it fail to give an error  (i.e., `$DIALOG" nib --wait`).
