### PR TITLE
Write to stderr if «token» does not exist when calling `nib update`

### DIFF
--- a/Commands/nib/nib.mm
+++ b/Commands/nib/nib.mm
@@ -85,7 +85,7 @@ env|egrep 'DIALOG|TM_SUPPORT'|grep -v DIALOG_1|perl -pe 's/(.*?)=(.*)/export $1=
 	{
 		if(TMDNibController* nibController = [Nibs objectForKey:updateToken])
 				[nibController updateParametersWith:model];
-		else	[proxy writeStringToOutput:@"There is no nib with that token"];
+		else	[proxy writeStringToError:@"There is no nib with that token"];
 	}
 
 	if(NSString* waitToken = [args objectForKey:@"wait"])


### PR DESCRIPTION
Ideally, `"$DIALOG"` should return an non-zero error code in these situations, but since there is no mechanism for that currently, checking if the command failed by examining stderr is probably the best (quick) solution right now. Looking at the code as is, I guess we could change `(void)handleCommand:(CLIProxy*)proxy` to return an `int` and propagate it all the way up the call chain. Thoughts?
