### PR TITLE
Reinstate "Replace deprecated method for initializing nibs (10.8)"

### DIFF
--- a/Commands/nib/TMDNibController.mm
+++ b/Commands/nib/TMDNibController.mm
@@ -51,9 +51,13 @@ static NSInteger NibTokenCount = 0;
 {
 	if(self = [self init])
 	{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-		if(NSNib* nib = [[NSNib alloc] initWithContentsOfURL:[NSURL fileURLWithPath:aPath]])
+		NSData* nibData;
+		NSString* keyedObjectsNibPath = [aPath stringByAppendingPathComponent:@"keyedobjects.nib"];
+		if([[NSFileManager defaultManager] fileExistsAtPath:keyedObjectsNibPath])
+			nibData = [NSData dataWithContentsOfFile:keyedObjectsNibPath];
+		else	nibData = [NSData dataWithContentsOfFile:aPath];
+
+		if(NSNib* nib = [[NSNib alloc] initWithNibData:nibData bundle:nil])
 		{
 			BOOL didInstantiate = NO;
 			NSArray* objects;
@@ -79,7 +83,6 @@ static NSInteger NibTokenCount = 0;
 		{
 			NSLog(@"%s failed loading nib: %@", sel_getName(_cmd), aPath);
 		}
-#pragma clang diagnostic pop
 	}
 	return nil;
 }


### PR DESCRIPTION
This reinstates commit 73ce03f ("Replace deprecated method for
initializing nibs (10.8)"). The problem was the use of NSWorkspace's
`isFilePackageAtPath:` to determine if the nib was compiled or not,
since it appears that Xcode.app defines .nib as a file package and not
the OS. Therefore, the previous check would fail for users without
Xcode installed.

This version just simply checks if the file keyedobjects.nib exist.